### PR TITLE
ci: use shared auto-merge-deps reusable

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -4,32 +4,16 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-merge:
-    name: Auto-merge dependency PRs
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
-
-    steps:
-      - name: Dependabot metadata
-        id: metadata
-        if: github.event.pull_request.user.login == 'dependabot[bot]'
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Auto-approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      # This repo only allows merge commits (squash/rebase are disabled), and
+      # the previous inline job hardcoded `gh pr merge --auto --merge`, so pin
+      # the strategy rather than relying on the reusable's auto-detection.
+      merge-strategy: merge


### PR DESCRIPTION
Replaces the inline `dependabot/fetch-metadata` + gh approve/merge job with a call to the shared [`auto-merge-deps.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/auto-merge-deps.yml).

**Zero step-level actions remain in this repo.**

Verified before migrating:
- Repo allows **merge commits only** (`allow_squash_merge: false`, `allow_rebase_merge: false`) and the old job hardcoded `gh pr merge --auto --merge`. The reusable auto-detects strategy squash-first, so `merge-strategy: merge` is pinned to preserve behaviour.
- The old job's `if: dependabot|renovate` author guard is implemented inside the reusable.
- Old job used `--auto` (not a poll loop), so it is compatible with the reusable's `--auto` merge.

Part of the fleet-wide stray-actions migration (Phase 0).