### PR TITLE
fix(docs): replace dead rawgit.com CDN with jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Modern browsers (IE >= 10) - tested in Chrome 53, Firefox 35 - 47, IE 10 - 11, E
 The easiest way to integrate AssetPicker is to use include the picker script from a CDN:
  
 ```html
-<script src="https://cdn.rawgit.com/netresearch/assetpicker/1.3.4/dist/js/picker.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/netresearch/assetpicker@1.3.4/dist/js/picker.js"></script>
 
 <script>
     new AssetPicker(config, options);

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <title>AssetPicker</title>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/paper/bootstrap.min.css">
-        <link rel="stylesheet" href="https://rawgit.com/abodelot/jquery.json-viewer/v1.1.0/json-viewer/jquery.json-viewer.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/abodelot/jquery.json-viewer@v1.1.0/json-viewer/jquery.json-viewer.css">
         <style type="text/css">
             a.json-toggle.collapsed:before {
                 font-size: 10px;
@@ -73,7 +73,7 @@
         </style>
         <!--<script src="../dist/js/picker.js"></script>-->
         <script>
-            document.write('\x3Cscript type="text/javascript" src="' + (document.location.hostname === 'localhost' ? '../dist/js/picker.js' : 'https://rawgit.com/netresearch/assetpicker/master/dist/js/picker.js') + '">\x3C/script>');
+            document.write('\x3Cscript type="text/javascript" src="' + (document.location.hostname === 'localhost' ? '../dist/js/picker.js' : 'https://cdn.jsdelivr.net/gh/netresearch/assetpicker@main/dist/js/picker.js') + '">\x3C/script>');
         </script>
 
         <script>
@@ -296,7 +296,7 @@
         <h4 id="usage">Usage</h4>
         <hr>
         <p>Actually it's just including the script from a CDN, instanciating the picker with some storages and have buttons with rel="assetpicker" attribute. However there are a lot more options which you can find in the <a href="https://github.com/netresearch/assetpicker#assetpicker">manual</a></p>
-        <pre>&lt;script src="https://cdn.rawgit.com/netresearch/assetpicker/1.0.0/dist/js/picker.js"&gt;&lt;/script&gt;
+        <pre>&lt;script src="https://cdn.jsdelivr.net/gh/netresearch/assetpicker@1.3.4/dist/js/picker.js"&gt;&lt;/script&gt;
 &lt;script&gt;
     new AssetPicker({
         storages: {
@@ -313,7 +313,7 @@
 
     <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-    <script src="https://rawgit.com/abodelot/jquery.json-viewer/v1.1.0/json-viewer/jquery.json-viewer.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/abodelot/jquery.json-viewer@v1.1.0/json-viewer/jquery.json-viewer.js"></script>
 
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
## Problem
`https://netresearch.github.io/assetpicker/` is broken:
```
GET https://rawgit.com/netresearch/assetpicker/master/dist/js/picker.js  404
GET https://rawgit.com/abodelot/jquery.json-viewer/v1.1.0/...            404
Uncaught ReferenceError: AssetPicker is not defined
```
**rawgit.com was sunset in 2019** — every rawgit URL now 404s. The demo also still pointed at the pre-rename `/master/` branch.

## Fix
Repoint all rawgit URLs to **jsDelivr** (`cdn.jsdelivr.net/gh/...`), the canonical GitHub-file CDN:
- demo `picker.js` → `@main` (tracks current build; replaces the dead `/master/`)
- README + demo CDN example → `@1.3.4` (pinned release)
- `jquery.json-viewer` → `@v1.1.0` (same pin)

Files: `docs/index.html` (the Pages source is `main:/docs`), `README.md`.

## Verification
All four jsDelivr targets return **HTTP 200** (rawgit returned 404). Pages redeploys from `main:/docs` on merge.

## Note (not fixed here, out of scope)
The demo injects the cross-site `picker.js` via `document.write`, which Chrome warns may be blocked on poor connectivity. Fixing the 404 restores the demo; converting that to a normal async `<script>` would remove the warning but is a separate change.