### PR TITLE
docs: align package descriptions with the Vue 3 reality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "netresearch/assetpicker",
-    "description": "A free asset or file picker with abstraction layer allowing several adapters like GitHub, EnterMediaDB, Amazon S3, Google Drive, Dropbox etc.",
+    "description": "Embeddable Vue 3 asset & file picker with a pluggable storage-adapter layer — GitHub, Google Drive, EnterMediaDB, or your own.",
+    "keywords": ["asset-picker", "file-picker", "media-library", "vue", "github", "google-drive", "entermediadb"],
     "type": "library",
     "authors": [
         {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,18 @@
 {
   "name": "assetpicker",
   "version": "1.3.4",
-  "description": "A free asset or file picker with abstraction layer allowing several adapters like GitHub, EnterMediaDB, Amazon S3, Google Drive, Dropbox etc.",
+  "description": "Embeddable Vue 3 asset & file picker with a pluggable storage-adapter layer — GitHub, Google Drive, EnterMediaDB, or your own.",
+  "keywords": [
+    "asset-picker",
+    "file-picker",
+    "file-manager",
+    "media-library",
+    "vue",
+    "vue3",
+    "github",
+    "google-drive",
+    "entermediadb"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/netresearch/assetpicker.git"


### PR DESCRIPTION
The `composer.json`/`package.json` `description` still advertised adapters that never existed (**Amazon S3, Dropbox**) and predated the Vue 3 rewrite. Aligned both to the updated GitHub repo description and added `keywords`.

Also updated on GitHub directly: the repo **description** (same text) and **topics** (`vue`, `vue3`, `vite`, `asset-picker`, `file-picker`, `file-manager`, `media-library`, `github`, `google-drive`, `entermediadb`, `netresearch` — was just `application`). `homepage` already points at the demo; README is current.