### PR TITLE
fix(ci): accept a tag input on manual release dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,15 @@ on:
       # via `prerelease: auto`. A v-prefixed tag does not match.
       - '[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
+    inputs:
+      # `create-github-release: true` needs a tag. Dispatching from a branch
+      # with this empty ends the run in the reusable's input validation, so a
+      # re-run of a failed tag-push release has to name the tag here.
+      tag:
+        description: 'Existing tag to release (e.g. 2.0.0). Leave empty only when dispatching on a tag ref.'
+        type: string
+        required: false
+        default: ''
 
 permissions: {}
 
@@ -39,6 +48,8 @@ jobs:
       package-manager: npm
       install-cmd: ''
       build-cmd: ''
+      # Empty on a tag push, where the reusable falls back to the ref.
+      tag: ${{ inputs.tag || '' }}
       # Fails the run if the tag and package.json version disagree.
       version-source: manifest-verified
       publish-npm: false


### PR DESCRIPTION
The `Release` run dispatched on `main` on 2026-07-28 ([run 30373084777](https://github.com/netresearch/assetpicker/actions/runs/30373084777)) failed in the reusable's `Validate inputs` step:

> create-github-release needs a tag, but the 'tag' input is empty and this run is on a branch ref ('main'). Dispatch the workflow on the tag, pass the 'tag' input, or set create-github-release: false.

`workflow_dispatch` declared no inputs, so there was no way to pass one — the trigger could only ever succeed when dispatched on a tag ref.

This adds the `tag` input and forwards it to `netresearch/.github/.github/workflows/node-release.yml`. On a tag push `inputs.tag` is undefined and resolves to `''`, so the reusable falls back to the ref as before.

Separate from this PR: `main` is at `chore(release): 2.0.0` and `package.json` says `2.0.0`, but no `2.0.0` tag exists — the highest tag is `1.3.4`. The 2.0.0 release still needs its signed tag pushed.
